### PR TITLE
fix run.sh if current dir contains spaces

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,6 @@ docker run --rm -it \
     -u $(id -u) \
     --device /dev/kvm \
     --group-add=$(getent group kvm | cut -d : -f 3) \
-    -v ${PWD}:/root \
+    -v "${PWD}:/root" \
     3mdeb/debos-docker \
     /bin/bash -c "debos $*"


### PR DESCRIPTION
`run.sh` would fail if the current path contains spaces due to the -v option being split. This adds a couple of `"` around the parameter to fix the issue.